### PR TITLE
Fix mismatch between function heads/prototypes/pointer types

### DIFF
--- a/src/gjiten.c
+++ b/src/gjiten.c
@@ -167,7 +167,7 @@ gjiten_quit_if_all_windows_closed()
  * Cleanly close gjiten from anywhere in the code
  **/
 void
-gjiten_quit()
+gjiten_quit(GSimpleAction *xa, GVariant *xb, void *xc)
 {
   // Close all windows
   // (gjiten_quit_if_all_windows_closed () will be called inside there)
@@ -178,7 +178,7 @@ gjiten_quit()
 
 
 void
-gjiten_start_kanjipad()
+gjiten_start_kanjipad(GSimpleAction *xa, GVariant *xb, void *xc)
 {
   FILE *kanjipad_binary;
   char *kpad_cmd;
@@ -239,8 +239,8 @@ gjiten_display_manual(GtkWidget *parent_window_nullable,
 
 
 
-void
-gjiten_show_whatsnew()
+static void
+gjiten_show_whatsnew(GSimpleAction *xa, GVariant *xb, void *xc)
 {
   GtkTextBuffer *textbuffer = gtk_text_buffer_new (NULL);
 
@@ -298,8 +298,8 @@ gjiten_show_whatsnew()
 
 
 
-void
-gjiten_create_about()
+static void
+gjiten_create_about(GSimpleAction *, GVariant *, void *)
 {
   const gchar *authors[] = { "Botond Botyanszki <boti@rocketmail.com>, DarkTrick", NULL };
   const gchar *documenters[] = { NULL };
@@ -483,7 +483,7 @@ gjiten_start_worddic(GtkApplication *app){
     gtk_window_present (GTK_WINDOW (gjitenApp->worddic));
   }
 
-  GjWorddicWindow *window = worddic_create (app);
+  GjWorddicWindow *window = worddic_create ();
   gjitenApp->worddic = window;
   _start_window (GTK_WINDOW (window));
 }
@@ -497,7 +497,7 @@ gjiten_start_kanjidic(GtkApplication *app)
     gtk_window_present (GTK_WINDOW (gjitenApp->kanjidic));
   }
 
-  GjKanjidicWindow *window = kanjidic_create (app);
+  GjKanjidicWindow *window = kanjidic_create ();
   gjitenApp->kanjidic = window;
   _start_window (GTK_WINDOW (window));
 }

--- a/src/gjiten.h
+++ b/src/gjiten.h
@@ -38,9 +38,9 @@ struct _GjitenApp {
 
 GtkApplication * gjiten_new();
 
-void gjiten_start_kanjipad();
-void gjiten_start_worddic();
-void gjiten_start_kanjidic();
+void gjiten_start_kanjipad(GSimpleAction *, GVariant *, void *);
+void gjiten_start_worddic(GtkApplication *);
+void gjiten_start_kanjidic(GtkApplication *);
 void gjiten_start_kanjidic_with_search(gunichar kanji);
 
 void gjiten_apply_fonts(GjitenApp * gjitenApp);

--- a/src/migration2-6_3-0.c
+++ b/src/migration2-6_3-0.c
@@ -384,7 +384,7 @@ migrate_2_6_to_3_0(const gchar *new_storage_dir,
     if (_store_available_gsettings())
       succ = _migrate_gsettings (&self, new_storage_dir, new_storage_file);
     else
-    if (_store_available_gconf (&self))
+    if (_store_available_gconf ())
       succ = _migrate_gconf (&self, new_storage_dir, new_storage_file);
   }
 

--- a/src/migration2-6_3-0.h
+++ b/src/migration2-6_3-0.h
@@ -4,7 +4,7 @@
 #define __MIGRATION2_6_3_0_H__
 
 gboolean migration_possible_2_6_to_3_0();
-gboolean migrate_2_6_to_3_0 ();
+gboolean migrate_2_6_to_3_0 (const gchar *, const gchar *);
 
 
 #endif

--- a/src/pref.c
+++ b/src/pref.c
@@ -459,7 +459,7 @@ checkbutton_envvar_cb(GtkWidget *button)
 
 
 void
-create_dialog_preferences()
+create_dialog_preferences(GSimpleAction *xa, GVariant *xb, void *xc)
 {
   GtkWidget *button;
   GtkWidget *tmpwidget;

--- a/src/pref.h
+++ b/src/pref.h
@@ -24,7 +24,7 @@
 #ifndef __PREF_H__
 #define __PREF_H__
 
-void create_dialog_preferences();
+void create_dialog_preferences(GSimpleAction *, GVariant *, void *);
 
 
 #endif


### PR DESCRIPTION
Support GCC 15.

```
gjiten.c: In function ‘_action_start_kanjipad’:
gjiten.c:356:3: error: too many arguments to function ‘gjiten_start_kanjidic’; expected 0, have 1
  356 |   gjiten_start_kanjidic (GTK_APPLICATION (gtk_application));
In file included from gjiten.c:45:
gjiten.h:43:6: note: declared here
   43 | void gjiten_start_kanjidic();
gjiten.c: In function ‘_action_start_worddic’:
gjiten.c:366:3: error: too many arguments to function ‘gjiten_start_worddic’; expected 0, have 1
  366 |   gjiten_start_worddic (GTK_APPLICATION (gtk_application));
gjiten.h:42:6: note: declared here
   42 | void gjiten_start_worddic();
gjiten.c: In function ‘_gjiten_create_menu’:
gjiten.c:449:43: error: initialization of ‘void (*)(GSimpleAction *, GVariant *, void *)’ {aka ‘void (*)(struct _GSimpleAction *, struct _GVariant *, void *)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  449 |         {.name="quit",          .activate=gjiten_quit },
gjiten.c:449:43: note: (near initialization for ‘actions[0].activate’)
gjiten.c:170:1: note: ‘gjiten_quit’ declared here
  170 | gjiten_quit()
gjiten.c:450:43: error: initialization of ‘void (*)(GSimpleAction *, GVariant *, void *)’ {aka ‘void (*)(struct _GSimpleAction *, struct _GVariant *, void *)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  450 |         {.name="preferences",   .activate=create_dialog_preferences },
gjiten.c:450:43: note: (near initialization for ‘actions[1].activate’)
In file included from gjiten.c:44:
pref.h:27:6: note: ‘create_dialog_preferences’ declared here
   27 | void create_dialog_preferences();
gjiten.c:451:43: error: initialization of ‘void (*)(GSimpleAction *, GVariant *, void *)’ {aka ‘void (*)(struct _GSimpleAction *, struct _GVariant *, void *)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  451 |         {.name="startKanjipad", .activate=gjiten_start_kanjipad },
gjiten.c:451:43: note: (near initialization for ‘actions[2].activate’)
gjiten.c:181:1: note: ‘gjiten_start_kanjipad’ declared here
  181 | gjiten_start_kanjipad()
gjiten.c:452:46: error: initialization of ‘void (*)(GSimpleAction *, GVariant *, void *)’ {aka ‘void (*)(struct _GSimpleAction *, struct _GVariant *, void *)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  452 |         {.name="showWhatsNew",     .activate=gjiten_show_whatsnew },
gjiten.c:452:46: note: (near initialization for ‘actions[3].activate’)
gjiten.c:243:1: note: ‘gjiten_show_whatsnew’ declared here
  243 | gjiten_show_whatsnew()
gjiten.c:453:43: error: initialization of ‘void (*)(GSimpleAction *, GVariant *, void *)’ {aka ‘void (*)(struct _GSimpleAction *, struct _GVariant *, void *)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  453 |         {.name="showAbout",     .activate=gjiten_create_about },
gjiten.c:453:43: note: (near initialization for ‘actions[4].activate’)
gjiten.c:302:1: note: ‘gjiten_create_about’ declared here
  302 | gjiten_create_about()
gjiten.c: At top level:
gjiten.c:480:1: error: conflicting types for ‘gjiten_start_worddic’; have ‘void(GtkApplication *)’ {aka ‘void(struct _GtkApplication *)’}
  480 | gjiten_start_worddic(GtkApplication *app){
gjiten.h:42:6: note: previous declaration of ‘gjiten_start_worddic’ with type ‘void(void)’
   42 | void gjiten_start_worddic();
gjiten.c: In function ‘gjiten_start_worddic’:
gjiten.c:486:29: error: too many arguments to function ‘worddic_create’; expected 0, have 1
  486 |   GjWorddicWindow *window = worddic_create (app);
In file included from gjiten.c:42:
worddic.h:54:18: note: declared here
   54 | GjWorddicWindow* worddic_create();
gjiten.c: At top level:
gjiten.c:494:1: error: conflicting types for ‘gjiten_start_kanjidic’; have ‘void(GtkApplication *)’ {aka ‘void(struct _GtkApplication *)’}
  494 | gjiten_start_kanjidic(GtkApplication *app)
gjiten.h:43:6: note: previous declaration of ‘gjiten_start_kanjidic’ with type ‘void(void)’
   43 | void gjiten_start_kanjidic();
gjiten.c: In function ‘gjiten_start_kanjidic’:
gjiten.c:500:30: error: too many arguments to function ‘kanjidic_create’; expected 0, have 1
  500 |   GjKanjidicWindow *window = kanjidic_create (app);
In file included from gjiten.c:43:
kanjidic.h:59:19: note: declared here
   59 | GjKanjidicWindow *kanjidic_create();
```